### PR TITLE
解决登陆时间过长要重新登陆的问题

### DIFF
--- a/PC.js
+++ b/PC.js
@@ -10,6 +10,7 @@
 // ==/UserScript==
 
 (function () {
+    pageTimer.stop();
     $("head").append($(`<link href="https://cdn.bootcdn.net/ajax/libs/bootstrap-switch/3.3.4/css/bootstrap3/bootstrap-switch.min.css"
     rel="stylesheet">`));
     $("head").append($(`<script src="https://cdn.bootcdn.net/ajax/libs/bootstrap-switch/3.3.4/js/bootstrap-switch.min.js"></script>`));


### PR DESCRIPTION
观察login(),发现在两种情况下会转到登录界面。一是没有登陆而进行选座，二是登陆时间超时。pageTimer.stop()可以将页面时间停止，这样在登陆后可以保持登陆状态不变，不用重新登陆。